### PR TITLE
Add options for destination port, giaddr, and dhcp server address

### DIFF
--- a/dhtest.c
+++ b/dhtest.c
@@ -57,6 +57,7 @@ u_int16_t fqdn_s = 0;
 u_int32_t option51_lease_time = 0;
 u_int32_t port = 67;
 u_char *giaddr = "0.0.0.0";
+u_char *server_addr = "255.255.255.255";
 
 /* Pointers for all layer data structures */
 struct ethernet_hdr *eth_hg = { 0 };
@@ -108,6 +109,7 @@ void print_help(char *cmd)
 	fprintf(stdout, "  -p, --padding\t\t\t\t# Add padding to packet to be at least 300 bytes\n");
 	fprintf(stdout, "  -P, --port\t\t[ port ]\t# Use port instead of 67\n");
 	fprintf(stdout, "  -g, --giaddr\t\t[ giaddr ]\t# Use giaddr instead of 0.0.0.0\n");
+	fprintf(stdout, "  -S, --server\t\t[ address ]\t# Use server address instead of 255.255.255.255\n");
 	fprintf(stdout, "  -V, --verbose\t\t\t\t# Prints DHCP offer and ack details\n");
 	fprintf(stdout, "  dhtest version 1.2\n");
 }
@@ -144,13 +146,14 @@ int main(int argc, char *argv[])
 		{ "padding", no_argument, 0, 'p'},
 		{ "port", required_argument, 0, 'P'},
 		{ "giaddr", required_argument, 0, 'g'},
+		{ "server", required_argument, 0, 'S'},
 		{ "release", no_argument, 0, 'r'},
 		{ 0, 0, 0, 0 }
 	};
 
 	/*getopt routine to get command line arguments*/
 	while(get_tmp < argc) {
-		get_cmd  = getopt_long(argc, argv, "m:i:v:t:bfVrpT:P:g:I:o:k:L:h:n:s:d:",\
+		get_cmd  = getopt_long(argc, argv, "m:i:v:t:bfVrpT:P:g:S:I:o:k:L:h:n:s:d:",\
 				long_options, &option_index);
 		if(get_cmd == -1 ) {
 			break;
@@ -284,6 +287,10 @@ int main(int argc, char *argv[])
 
 			case 'g':
 				giaddr = optarg;
+				break;
+
+			case 'S':
+				server_addr = optarg;
 				break;
 
 			case 'p':

--- a/functions.c
+++ b/functions.c
@@ -45,6 +45,7 @@ extern u_int8_t fqdn_buff[256];
 extern u_int32_t option51_lease_time;
 extern u_int32_t port;
 extern u_char *giaddr;
+extern u_char *server_addr;
 
 extern struct ethernet_hdr *eth_hg;
 extern struct vlan_hdr *vlan_hg; 
@@ -632,7 +633,7 @@ int build_dhpacket(int pkt_type)
 		iph->protocol = 17;
 		iph->check = 0; // Filled later;
 		iph->saddr = inet_addr("0.0.0.0");
-		iph->daddr = inet_addr("255.255.255.255");
+		iph->daddr = inet_addr(server_addr);
 		iph->check = ipchksum((u_int16_t *)(dhcp_packet_disc + l2_hdr_size), iph->ihl << 1);
 
 		struct udphdr *uh = (struct udphdr *) (dhcp_packet_disc + l2_hdr_size + l3_hdr_size);
@@ -699,7 +700,7 @@ int build_dhpacket(int pkt_type)
 		iph->protocol = 17;
 		iph->check = 0; // Filled later;
 		iph->saddr = inet_addr("0.0.0.0");
-		iph->daddr = inet_addr("255.255.255.255");
+		iph->daddr = inet_addr(server_addr);
 		iph->check = ipchksum((u_int16_t *)(dhcp_packet_request + l2_hdr_size), iph->ihl << 1);
 
 		struct udphdr *uh = (struct udphdr *) (dhcp_packet_request + l2_hdr_size + l3_hdr_size);


### PR DESCRIPTION
The commits below add some minor functionality.  The "-P" one is most useful for me, as it lets me test the DHCP functionality on another port, so I don't break my production network!

Adding giaddr is also useful, as is the server address.
