### PR TITLE
Fixed tool running longer than timeout

### DIFF
--- a/dhtest.c
+++ b/dhtest.c
@@ -541,7 +541,7 @@ int main(int argc, char *argv[])
 
 		if(timeout) {
 			time_now = time(NULL);
-			if((time_now - time_last) > timeout) {
+			if((time_now - time_last) >= timeout) {
 				if (nagios_flag)
 					fprintf(stdout, "CRITICAL: Timeout reached: DISCOVER.");
 				close_socket();


### PR DESCRIPTION
When you execute dhtest with -T 5 -k 5 it runs actually much longer. This patch fixes this behavior.