### PR TITLE
Fixed format strings of json output

### DIFF
--- a/dhtest.c
+++ b/dhtest.c
@@ -722,7 +722,7 @@ int main(int argc, char *argv[])
 					json_first = 0;
 				}
 
-				fprintf(stdout, "{\"msg\":\"DHCP nack received - %s\","
+				fprintf(stdout, "{\"msg\":\"DHCP nack received\","
                                                 "\"result\":\"info\","
                                                 "\"result-type\":\"NACK\","
                                                 "\"result-value\":\"%02x:%02x:%02x:%02x:%02x:%02x\""

--- a/functions.c
+++ b/functions.c
@@ -1154,7 +1154,7 @@ int check_packet(int pkt_type)
 						json_first = 0;
 					}
 
-					fprintf(stdout, "{\"msg\":\"Arp request received - %s\","
+					fprintf(stdout, "{\"msg\":\"Arp request received\","
                                                 "\"result\":\"success\","
                                                 "\"result-type\":\"arp-received\"}");
 				} else {


### PR DESCRIPTION
Accidentially included some "%s" operations in two format strings which
caused the compiler to warn.