### PR TITLE
Fixed compiler warning related to custom options

### DIFF
--- a/dhtest.c
+++ b/dhtest.c
@@ -344,7 +344,7 @@ int main(int argc, char *argv[])
                                     //memcpy(custom_dhcp_options[option_index].option_value, option_value, sizeof(custom_dhcp_options[option_index].option_value));
                                     int tmp, index = 0;
                                     for(tmp = 0; tmp < hex_length; tmp++) {
-                                        sscanf(&option_value[index], "%2X", &custom_dhcp_options[option_index].option_value[tmp]);
+                                        sscanf(&option_value[index], "%2X", (unsigned int*)&custom_dhcp_options[option_index].option_value[tmp]);
                                         index = index + 2;
                                     }
 


### PR DESCRIPTION
Added explicit cast for custom hex dhcp option.

Tested and working on my machine. Please look over this one and check if the unsigned int pointer has any unwanted effects. I have not found any and I believe that the compiler did in fact just cast it to unsigned int as the format string "%X" of ssprintf suggests.