### PR TITLE
Clang warnings fix

### DIFF
--- a/dhtest.c
+++ b/dhtest.c
@@ -344,7 +344,7 @@ int main(int argc, char *argv[])
                                     //memcpy(custom_dhcp_options[option_index].option_value, option_value, sizeof(custom_dhcp_options[option_index].option_value));
                                     int tmp, index = 0;
                                     for(tmp = 0; tmp < hex_length; tmp++) {
-                                        sscanf(&option_value[index], "%2X", &custom_dhcp_options[option_index].option_value[tmp]);
+                                        sscanf(&option_value[index], "%2X", (unsigned int*)&custom_dhcp_options[option_index].option_value[tmp]);
                                         index = index + 2;
                                     }
 

--- a/dhtest.c
+++ b/dhtest.c
@@ -70,8 +70,8 @@ u_int8_t unicast_flag = 0;
 u_int8_t nagios_flag = 0;
 u_int8_t json_flag = 0;
 u_int8_t json_first = 1;
-u_char *giaddr = "0.0.0.0";
-u_char *server_addr = "255.255.255.255";
+char *giaddr = "0.0.0.0";
+char *server_addr = "255.255.255.255";
 
 /* Pointers for all layer data structures */
 struct ethernet_hdr *eth_hg = { 0 };
@@ -296,7 +296,7 @@ int main(int argc, char *argv[])
                                 //format - option_no_dec,str|num|hex|ip,option_value
                                 
                                 u_int8_t option_no, option_type;
-                                u_char option_value[256] = { 0 };
+                                char option_value[256] = { 0 };
                                 u_int32_t option_value_num = { 0 }, option_value_ip = { 0 };
                                 int option_index = 0;
                                 int scanf_state;

--- a/functions.c
+++ b/functions.c
@@ -460,6 +460,8 @@ int recv_packet(int pkt_type)
 		}
 		return LISTEN_TIMOUET;
 	}
+
+    return UNKNOWN_PACKET;
 }
 
 /* Debug function - Prints the buffer on HEX format */
@@ -1175,6 +1177,8 @@ int check_packet(int pkt_type)
 		}
 		return UNKNOWN_PACKET;
 	}
+    
+    return UNKNOWN_PACKET;
 }
 
 /*


### PR DESCRIPTION
Here I fixed some warnings of clang.

Before fix:
```
hostname:~/src/dhtest$ clang dhtest.c functions.c 
dhtest.c:73:9: warning: initializing 'u_char *' (aka 'unsigned char *') with an expression of type 'char [8]' converts between pointers to integer types with different sign [-Wpointer-sign]
u_char *giaddr = "0.0.0.0";
        ^        ~~~~~~~~~
dhtest.c:74:9: warning: initializing 'u_char *' (aka 'unsigned char *') with an expression of type 'char [16]' converts between pointers to integer types with different sign [-Wpointer-sign]
u_char *server_addr = "255.255.255.255";
        ^             ~~~~~~~~~~~~~~~~~
dhtest.c:305:49: warning: passing 'u_char [256]' to parameter of type 'const char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                    if ((strlen(option_value) >= 256)) {
                                                ^~~~~~~~~~~~
/usr/include/string.h:398:35: note: passing argument to parameter '__s' here
extern size_t strlen (const char *__s)
                                  ^
dhtest.c:328:49: warning: passing 'u_char [256]' to parameter of type 'const char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                    if ((strlen(option_value) >= 255)) {
                                                ^~~~~~~~~~~~
/usr/include/string.h:398:35: note: passing argument to parameter '__s' here
extern size_t strlen (const char *__s)
                                  ^
dhtest.c:347:48: warning: passing 'u_char *' (aka 'unsigned char *') to parameter of type 'const char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                        sscanf(&option_value[index], "%2X", &custom_dhcp_options[option_index].option_value[tmp]);
                                               ^~~~~~~~~~~~~~~~~~~~
/usr/include/stdio.h:448:60: note: passing argument to parameter '__s' here
extern int __REDIRECT_NTH (sscanf, (const char *__restrict __s,
                                                           ^
/usr/include/x86_64-linux-gnu/sys/cdefs.h:185:11: note: expanded from macro '__REDIRECT_NTH'
     name proto __asm__ (__ASMNAME (#alias)) __THROW
          ^
dhtest.c:347:77: warning: format specifies type 'unsigned int *' but the argument has type 'u_char *' (aka 'unsigned char *') [-Wformat]
                                        sscanf(&option_value[index], "%2X", &custom_dhcp_options[option_index].option_value[tmp]);
                                                                      ~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                      %2s
dhtest.c:412:12: warning: assigning to 'u_char *' (aka 'unsigned char *') from 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                giaddr = optarg;
                                       ^ ~~~~~~
dhtest.c:416:17: warning: assigning to 'u_char *' (aka 'unsigned char *') from 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                server_addr = optarg;
                                            ^ ~~~~~~
8 warnings generated.
functions.c:463:1: warning: control may reach end of non-void function [-Wreturn-type]
}
^
functions.c:1178:1: warning: control may reach end of non-void function [-Wreturn-type]
}
^
2 warnings generated.
```

After fix:
```
hostname:~/src/dhtest$ clang dhtest.c functions.c 
```
(no warnings :)