### PR TITLE
Fixed json output syntax error

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -1225,7 +1225,7 @@ int print_dhinfo(int pkt_type)
 				get_ip_str(dhcph_g->dhcp_sip));
 
 			if(dhcph_g->dhcp_gip) {
-				fprintf(stdout, "\",result-relay-agent\":\"%s\"", get_ip_str(dhcph_g->dhcp_gip));
+				fprintf(stdout, ",\"result-relay-agent\":\"%s\"", get_ip_str(dhcph_g->dhcp_gip));
 			}
 
 			fprintf(stdout, "}");

--- a/functions.c
+++ b/functions.c
@@ -1252,12 +1252,12 @@ int print_dhinfo(int pkt_type)
                                 "\"result\":\"info\","
                                 "\"result-type\":\"ack\","
                                 "\"result-ip\":\"%s\","
-                                "\"result-next-srv\":\"%s\",", 
+                                "\"result-next-srv\":\"%s\"", 
                                 get_ip_str(dhcph_g->dhcp_yip), 
                                 get_ip_str(dhcph_g->dhcp_sip));
 
                         if(dhcph_g->dhcp_gip) {
-                                fprintf(stdout, "\"result-relay-agent\":\"%s\"", get_ip_str(dhcph_g->dhcp_gip));
+                                fprintf(stdout, ",\"result-relay-agent\":\"%s\"", get_ip_str(dhcph_g->dhcp_gip));
                         }
 
                         fprintf(stdout, "}");

--- a/functions.c
+++ b/functions.c
@@ -1220,12 +1220,12 @@ int print_dhinfo(int pkt_type)
 				"\"result\":\"info\","
 				"\"result-type\":\"offer\","
 				"\"result-ip\":\"%s\","
-				"\"result-next-srv\":\"%s\",",
+				"\"result-next-srv\":\"%s\"",
 				get_ip_str(dhcph_g->dhcp_yip),
 				get_ip_str(dhcph_g->dhcp_sip));
 
 			if(dhcph_g->dhcp_gip) {
-				fprintf(stdout, "\"result-relay-agent\":\"%s\"", get_ip_str(dhcph_g->dhcp_gip));
+				fprintf(stdout, "\",result-relay-agent\":\"%s\"", get_ip_str(dhcph_g->dhcp_gip));
 			}
 
 			fprintf(stdout, "}");


### PR DESCRIPTION
In one case a comma was printed before the closing brace of an object.