### PR TITLE
Provide prompt when no interface is specified

### DIFF
--- a/dhtest.c
+++ b/dhtest.c
@@ -464,6 +464,7 @@ int main(int argc, char *argv[])
 	}	
 
 	if(!*iface_name) {
+		fprintf(stderr, "No interface is specified.\n\n");
 		print_help(argv[0]);
 		exit(2);
 	}


### PR DESCRIPTION
According to this interface name check https://github.com/saravana815/dhtest/blob/master/dhtest.c#L466 , give a explicit prompt to users so users could be aware of the lack of the interface option immediately.