### PR TITLE
Add DHCP DECLINE support / fix Segmentation Fault

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,13 @@
         [sargandh@CentOS dhtest-master]$ ls -lh dhtest
         -rwxrwxr-x 1 sargandh sargandh 38K Mar 13 10:47 dhtest
 
+  dhtest 1.5 - new 1.5 features supported
+  -----------------------------------------
+  
+    * Add option to send DHCP DECLINE packets ('-D' flag)
+    * Fix potential Segmentation Fault in get_dhinfo() function
+
+
   dhtest 1.4 - till 1.4 features supported
   -----------------------------------------
   
@@ -33,14 +40,14 @@
     * DHCP option 50 - Requested IP
     * DHCP option 60 - Vendor Class Identifier
     * Binding obtained IP for a default timeout of 3600 seconds
-    * Support of bind timout with -k flag on command line
+    * Support of bind timeout with -k flag on command line
     * Added DHCP option 51 - Requested lease time from server
     * Added DHCP option 12 - Hostname
     * Added DHCP option 81 - Fqdn
     * Option to send in unicast mode.
     * Option to output for nagios.
     * Option to change port, patch by Alan Dekok.
-    * Custom option support - Allows packing of any dhcp option in number/string/hex formart
+    * Custom option support - Allows packing of any dhcp option in number/string/hex format
 
   License
   ---------

--- a/dhscript.py
+++ b/dhscript.py
@@ -63,6 +63,7 @@ def run_dhtest(mac, arg_list, search_output):
 #  -u, --unicast         [ ip ]          # Unicast request, IP is optional. If not specified, the interface address will be used. 
 #  -a, --nagios                          # Nagios output format. 
 #  -S, --server          [ address ]     # Use server address instead of 255.255.255.255
+#  -D, --decline                         # Declines obtained DHCP IP for corresponding MAC
 #  -V, --verbose                         # Prints DHCP offer and ack details
 
 mac = "00:00:00:11:11:11"
@@ -87,4 +88,5 @@ run_dhtest(mac, ' -g 10.0.2.1', "DHCP ack received")
 run_dhtest(mac, ' -a', "Acquired IP")
 run_dhtest(mac, ' -S 10.0.2.2 ', "DHCP ack received")
 run_dhtest(mac, ' -c 60,str,"MSFT 5.0" -c 82,hex,0108476967302f312f30021130303a30303a30303a31313a31313a3131 ', "DHCP ack received")
+run_dhtest(mac, ' -D',  "DHCP decline sent")
 


### PR DESCRIPTION
### This commit adds the following:
 - [x] Add support for sending DHCP DECLINE packets using the new '-D' flag.
     - _The DHCP DECLINE packet format is based on live examples captured with Wireshark.  (The DHCP DECLINE support is modeled very closely to the existing DHCP RELEASE implementation.)_
 - [x] Fix for Segmentation Fault in get_dhinfo() function.
    - _During testing of the DHCP DECLINE packet feature, it was discovered that the get_dhinfo() function would generate a Segmentation Fault when accessing/writing the last hex pair of the MAC address (i.e. fscanf("%02X")) when run on the Raspberry Pi 3.  To resolve this, a three-byte padding was added to the aux_dmac[] buffer._
 - [x] Minor typo fixes in README.txt.
 - [x] Bump revision from v1.4 to v1.5.

##### Here is sample python code used to expose the Segmentation Fault:
```python
    mac = "00:00:00:11:11:11"
    run_dhtest(mac, '', "DHCP ack received")
    time.sleep(1) #delay for 1 second
    run_dhtest(mac, ' -D', "DHCP decline sent")
```

##### A. Here is a sample of the Segmentation Fault indication that was observed:
```
=============================================================
Running command  ./dhtest -i eth0 -m 00:00:00:11:11:11 -D
out =  Segmentation fault
FAIL: command  ./dhtest -i eth0 -m 00:00:00:11:11:11 -D
============================================================
```

##### B. Here is the output after the Segmentation Fault was resolved:
```
=============================================================
Running command  ./dhtest -i eth0 -m 00:00:00:11:11:11
out =  DHCP discover sent	 - Client MAC : 00:00:00:11:11:11
DHCP offer received	 - Offered IP : 172.8.0.11
DHCP request sent	 - Client MAC : 00:00:00:11:11:11
DHCP ack received	 - Acquired IP: 172.8.0.11
PASS: command  ./dhtest -i eth0 -m 00:00:00:11:11:11
============================================================
=============================================================
Running command  ./dhtest -i eth0 -m 00:00:00:11:11:11 -D
out =  DHCP decline sent	 - Client MAC : 00:00:00:11:11:11
PASS: command  ./dhtest -i eth0 -m 00:00:00:11:11:11 -D
============================================================
```