### PR TITLE
Do not build option 60 if it was not specified.

### DIFF
--- a/dhtest.c
+++ b/dhtest.c
@@ -616,7 +616,10 @@ int main(int argc, char *argv[])
 		}
 		build_option54();		 /* Server id */
 		build_option50();		 /* Requested IP Address */
-		build_option60_vci();	 /* Vendor Class Identifier */
+
+		if(vci_flag) {
+			build_option60_vci();	 /* Vendor Class Identifier */
+		};
 		build_optioneof();		 /* End of option */
 		build_dhpacket(DHCP_MSGDECLINE); /* Build DHCP release packet */
 		send_packet(DHCP_MSGDECLINE);	 /* Send DHCP release packet */
@@ -643,7 +646,7 @@ int main(int argc, char *argv[])
 		build_option51();               /* Option51 - DHCP lease time requested */
 	}
 
-	if(vci_flag == 1) {
+	if(vci_flag) {
 		build_option60_vci(); 		/* Option60 - VCI  */
 	}
         /* Build custom options */
@@ -725,7 +728,7 @@ int main(int argc, char *argv[])
 	if(fqdn_flag) {
 		build_option81_fqdn();
 	}
-	if(vci_flag == 1) {
+	if(vci_flag) {
 		build_option60_vci();  
 	}
 	if(option51_lease_time) {


### PR DESCRIPTION
RFC 2132 doesn't allow option 60 to have zero length thus dhtest
should not build the option unless it was explicetely specified to.
Violation of this rule cause ignoring of DHCPDECLINE packet by some
server (like ISC KEA).