### PR TITLE
Add Dockerfile to allow Docker on Mac users to try dhtest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+# USAGE:
+# docker build -t dhtest .
+# docker run -ti --privileged dhtest dhtest -V -N -i eth0 --timeout 10
+
+ADD . /workspace
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y make gcc
+
+RUN make && mv dhtest /usr/bin
+


### PR DESCRIPTION
Example usage:

    docker build -t dhtest .
    docker run -ti --privileged dhtest dhtest -V -N -i eth0 --timeout 10

* [ ] confirm that responses can be received

    ```
    $ docker run -ti --privileged dhtest dhtest -V -N -i eth0 --timeout 10
    Using Ethernet source addr: 02:42:ac:11:00:05
    Using DHCP chaddr: 02:42:ac:11:00:05
    DHCP discover sent	 - Client MAC : 02:42:ac:11:00:05
    DHCP discover sent	 - Client MAC : 02:42:ac:11:00:05
    ^CDHCP discover sent	 - Client MAC : 02:42:ac:11:00:05
    ```

*FIXME:* Anyone with lovely ideas on getting dhtest working within Docker?