### PR TITLE
Build fix and strncpy fixes

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -614,8 +614,8 @@ int build_option53(int msg_type)
 		u_int8_t msg = DHCP_MSGDISCOVER;
 
 		memcpy(dhopt_buff, &msgtype, 1);
-                strncpy((char *) (dhopt_buff + 1), (char *) &msglen, 1);
-                strncpy((char *) (dhopt_buff + 2), (char *) &msg, 1);
+                memcpy(dhopt_buff + 1, &msglen, 1);
+                memcpy(dhopt_buff + 2, &msg, 1);
 		dhopt_size = dhopt_size + 3; 
 	} else if(msg_type == DHCP_MSGREQUEST) {
 		u_int8_t msgtype = DHCP_MESSAGETYPE;
@@ -623,8 +623,8 @@ int build_option53(int msg_type)
 		u_int8_t msg = DHCP_MSGREQUEST;
 
 		memcpy(dhopt_buff, &msgtype, 1);
-                strncpy((char *) (dhopt_buff + 1), (char *) &msglen, 1);
-                strncpy((char *) (dhopt_buff + 2), (char *) &msg, 1);
+                memcpy(dhopt_buff + 1, &msglen, 1);
+                memcpy(dhopt_buff + 2, &msg, 1);
 		dhopt_size = dhopt_size + 3; 
 	} else if(msg_type == DHCP_MSGRELEASE) {
 		u_int8_t msgtype = DHCP_MESSAGETYPE;
@@ -632,8 +632,8 @@ int build_option53(int msg_type)
 		u_int8_t msg = DHCP_MSGRELEASE;
 
 		memcpy(dhopt_buff, &msgtype, 1);
-                strncpy((char *) (dhopt_buff + 1), (char *) &msglen, 1);
-                strncpy((char *) (dhopt_buff + 2), (char *) &msg, 1);
+                memcpy(dhopt_buff + 1, &msglen, 1);
+                memcpy(dhopt_buff + 2, &msg, 1);
 		dhopt_size = dhopt_size + 3; 
 	} else if(msg_type == DHCP_MSGDECLINE) {
 		u_int8_t msgtype = DHCP_MESSAGETYPE;
@@ -641,8 +641,8 @@ int build_option53(int msg_type)
 		u_int8_t msg = DHCP_MSGDECLINE;
 
 		memcpy(dhopt_buff, &msgtype, 1);
-                strncpy((char *) (dhopt_buff + 1), (char *) &msglen, 1);
-                strncpy((char *) (dhopt_buff + 2), (char *) &msg, 1);
+                memcpy(dhopt_buff + 1, &msglen, 1);
+                memcpy(dhopt_buff + 2, &msg, 1);
 		dhopt_size = dhopt_size + 3; 
 	}
 	return 0;
@@ -1142,7 +1142,7 @@ int build_packet(int pkt_type)
 		u_int32_t ip_addr_tmp;
 		ip_addr_tmp = htonl(ip_address);
 		memcpy(arph->sender_mac, iface_mac, ETHER_ADDR_LEN);
-		memcpy(arph->sender_ip, (u_char *)&ip_addr_tmp, ETHER_ADDR_LEN);
+		memcpy(arph->sender_ip, (u_char *)&ip_addr_tmp, IP_ADDR_LEN);
 		memcpy(arph->target_mac, arp_hg->sender_mac, ETHER_ADDR_LEN);
 		memcpy(arph->target_ip, arp_hg->sender_ip, IP_ADDR_LEN);
 	} else if(ICMP_SEND) {
@@ -1810,7 +1810,7 @@ int get_if_mac_address(char *if_name, uint8_t *mac_address)
 
   // get the mac address ot the interface
   memset(&ifr, 0, sizeof(ifr));
-  strncpy(ifr.ifr_name, if_name, sizeof(ifr.ifr_name));
+  strncpy(ifr.ifr_name, if_name, sizeof(ifr.ifr_name)-1);
   if (ioctl(sockfd, SIOCGIFHWADDR, &ifr) != 0)
     {
       perror("Error getting interface's MAC address:");
@@ -1846,7 +1846,8 @@ int str2mac(char *str, uint8_t *mac_addr)
   if(!str || !mac_addr)
     return 1;
 
-  strncpy(local_mac_str, str, 25);
+  strncpy(local_mac_str, str, 24);
+  local_mac_str[24] = 0x00;
 
   // replace semicolons with end of string character
   local_mac_str[2] =  local_mac_str[5] =  local_mac_str[8] =  local_mac_str[11] =  local_mac_str[14] = 0x00;

--- a/functions.c
+++ b/functions.c
@@ -64,8 +64,8 @@ extern struct udphdr *uh_g;
 extern struct dhcpv4_hdr *dhcph_g;
 extern u_int8_t *dhopt_pointer_g;
 
-struct arp_hdr *arp_hg;
-struct icmp_hdr *icmp_hg;
+extern struct arp_hdr *arp_hg;
+extern struct icmp_hdr *icmp_hg;
 
 extern u_char dhmac[ETHER_ADDR_LEN];
 extern u_char dmac[ETHER_ADDR_LEN];


### PR DESCRIPTION
dhtest [stopped compiling under Fedora 32](https://bugzilla.redhat.com/show_bug.cgi?id=1799278) using GCC 10.0. First commit fixes build, the second improves wrong usage of strncpy in some places.