### PR TITLE
fix: l4_sum function

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -587,7 +587,7 @@ u_int16_t l4_sum(u_int16_t *buff, int words, u_int16_t *srcaddr, u_int16_t *dsta
 	/* Checksum enhancement - Support for odd byte packets */
 	if((htons(len) % 2) == 1) {
 		last_word = *((u_int8_t *)buff + ntohs(len) - 1);
-		last_word = (htons(last_word) << 8);
+		last_word = htons(last_word << 8);
 	} else {
 		/* Original checksum function */
 		last_word = 0;


### PR DESCRIPTION
Thanks for providing `dhtest`! We just found out that the UDP checksum is calculated incorrectly in some cases. This PR should fix this problem.