### PR TITLE
fix 'struct udphdr' has no member named '...' thanks to #19

### DIFF
--- a/headers.h
+++ b/headers.h
@@ -151,9 +151,9 @@ struct icmp_hdr
 };
 
 /*
- * UDP header included from netinet/udp.h
+ * UDP header included from linux/udp.h
  */
-#include<netinet/udp.h>
+#include<linux/udp.h>
 
 
 /*


### PR DESCRIPTION
cc https://github.com/saravana815/dhtest/issues/19#issuecomment-1077426790

Unlocks building on alpine and continues building fine on ubuntu.